### PR TITLE
fix: Corrigir load do analyzer nos testes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    # CodeQL não suporta PowerShell; repo é 100% PowerShell - permite falha sem bloquear PR
-    continue-on-error: true
+    # CodeQL não suporta PowerShell; rodamos somente GitHub Actions (workflows)
     permissions:
       security-events: write
       actions: read
@@ -26,10 +25,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: auto
+          languages: actions
           queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:default"
+          category: "/language:actions"

--- a/tests/analyzer.Tests.ps1
+++ b/tests/analyzer.Tests.ps1
@@ -2,7 +2,11 @@
 $script:analyzerPath = Join-Path (Split-Path $PSScriptRoot -Parent) "src\analyzer.ps1"
 
 BeforeAll {
-    . $script:analyzerPath
+    $resolved = (Resolve-Path -LiteralPath $script:analyzerPath).Path
+    if (-not $resolved) {
+        throw "Falha ao resolver caminho do analyzer.ps1: $script:analyzerPath"
+    }
+    . $resolved
 }
 
 Describe "Get-AggregatedMetrics" {

--- a/tests/analyzer.Tests.ps1
+++ b/tests/analyzer.Tests.ps1
@@ -1,11 +1,11 @@
 # Carrega o analyzer (Pester 5 pode separar discovery/run; use BeforeAll)
-$analyzerPath = Join-Path (Split-Path $PSScriptRoot -Parent) "src\analyzer.ps1"
+$script:analyzerPath = Join-Path (Split-Path $PSScriptRoot -Parent) "src\analyzer.ps1"
+
+BeforeAll {
+    . $script:analyzerPath
+}
 
 Describe "Get-AggregatedMetrics" {
-    BeforeAll {
-        . $analyzerPath
-    }
-
     It "calcula total de repos, stars e forks corretamente" {
         $user = [PSCustomObject]@{ login = "test" }
         $repos = @(
@@ -73,10 +73,6 @@ Describe "Get-AggregatedMetrics" {
 }
 
 Describe "Get-TableFromRows" {
-    BeforeAll {
-        . $analyzerPath
-    }
-
     It "gera HTML de tabela corretamente" {
         $headers = @("Col1", "Col2")
         $rows = @("| A | 1 |", "| B | 2 |")
@@ -89,10 +85,6 @@ Describe "Get-TableFromRows" {
 }
 
 Describe "Resolve-ReportPath" {
-    BeforeAll {
-        . $analyzerPath
-    }
-
     It "retorna OutputPath quando fornecido" {
         $path = Resolve-ReportPath -Username "test" -OutputPath "C:\custom\report.html"
         $path | Should -Be "C:\custom\report.html"
@@ -106,10 +98,6 @@ Describe "Resolve-ReportPath" {
 }
 
 Describe "Save-Report" {
-    BeforeAll {
-        . $analyzerPath
-    }
-
     It "cria arquivo e diretório se não existir" {
         $tempDir = Join-Path $env:TEMP "gh-analyzer-test-$(Get-Random)"
         $subDir = Join-Path $tempDir "subdir"

--- a/tests/analyzer.Tests.ps1
+++ b/tests/analyzer.Tests.ps1
@@ -1,11 +1,18 @@
-# Carrega o analyzer (Pester 5 pode separar discovery/run; use BeforeAll)
-$script:analyzerPath = Join-Path (Split-Path $PSScriptRoot -Parent) "src\analyzer.ps1"
-
 BeforeAll {
-    $resolved = (Resolve-Path -LiteralPath $script:analyzerPath).Path
-    if (-not $resolved) {
-        throw "Falha ao resolver caminho do analyzer.ps1: $script:analyzerPath"
+    # Pester/GitHub Actions podem isolar discovery/run; calcule o path aqui
+    $testFile = $MyInvocation.MyCommand.Path
+    if ([string]::IsNullOrWhiteSpace($testFile)) {
+        $testFile = $PSCommandPath
     }
+    if ([string]::IsNullOrWhiteSpace($testFile)) {
+        throw "Não foi possível determinar o caminho do arquivo de testes."
+    }
+
+    $testsDir = Split-Path -Parent $testFile
+    $repoRoot = Split-Path -Parent $testsDir
+    $analyzerPath = Join-Path $repoRoot "src\analyzer.ps1"
+
+    $resolved = (Resolve-Path -LiteralPath $analyzerPath).Path
     . $resolved
 }
 

--- a/tests/analyzer.Tests.ps1
+++ b/tests/analyzer.Tests.ps1
@@ -1,8 +1,11 @@
-# Carrega o analyzer (compatível com Pester 3 e 5)
+# Carrega o analyzer (Pester 5 pode separar discovery/run; use BeforeAll)
 $analyzerPath = Join-Path (Split-Path $PSScriptRoot -Parent) "src\analyzer.ps1"
-. $analyzerPath
 
 Describe "Get-AggregatedMetrics" {
+    BeforeAll {
+        . $analyzerPath
+    }
+
     It "calcula total de repos, stars e forks corretamente" {
         $user = [PSCustomObject]@{ login = "test" }
         $repos = @(
@@ -70,6 +73,10 @@ Describe "Get-AggregatedMetrics" {
 }
 
 Describe "Get-TableFromRows" {
+    BeforeAll {
+        . $analyzerPath
+    }
+
     It "gera HTML de tabela corretamente" {
         $headers = @("Col1", "Col2")
         $rows = @("| A | 1 |", "| B | 2 |")
@@ -82,6 +89,10 @@ Describe "Get-TableFromRows" {
 }
 
 Describe "Resolve-ReportPath" {
+    BeforeAll {
+        . $analyzerPath
+    }
+
     It "retorna OutputPath quando fornecido" {
         $path = Resolve-ReportPath -Username "test" -OutputPath "C:\custom\report.html"
         $path | Should -Be "C:\custom\report.html"
@@ -95,6 +106,10 @@ Describe "Resolve-ReportPath" {
 }
 
 Describe "Save-Report" {
+    BeforeAll {
+        . $analyzerPath
+    }
+
     It "cria arquivo e diretório se não existir" {
         $tempDir = Join-Path $env:TEMP "gh-analyzer-test-$(Get-Random)"
         $subDir = Join-Path $tempDir "subdir"


### PR DESCRIPTION
## Summary
- Ajusta os testes para carregar o analyzer no `BeforeAll` (Pester 5)

## Por qu?
- Evita `CommandNotFoundException` na fase de execu??o do Pester quando
  discovery/run rodam em contextos diferentes.

## Issues
- Closes #8

## Test plan
- Validar CI (Pester + ScriptAnalyzer) no PR
